### PR TITLE
Update spec file to have Requires for packages needed by generated spec

### DIFF
--- a/containment-rpm.spec
+++ b/containment-rpm.spec
@@ -26,9 +26,12 @@ Url:            https://github.com/openSUSE/%{name}
 Group:          System/Management
 Source:         %{name}-%{version}.tar.bz2
 BuildRequires:  filesystem
+# BuildRequires from the generated spec file, that need to be installed
+Requires:       bsdtar
+Requires:       containment-rpm-config
+Requires:       fdupes
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
-Requires:       containment-rpm-config
 
 %description
 OBS kiwi_post_run hook to wrap a kiwi-produced image in an rpm package.


### PR DESCRIPTION
The generated spec file has build requirements that need to be installed
to have a successful build; if we have them as Requires for
containment-rpm, then they will get automatically installed and they won't
require any additional change in the prjconf.
